### PR TITLE
Update main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -130,7 +130,7 @@ class Chatgpt {
     const markup = `
       <div class="chat">
         <div class="profile"><img src="${userAvatar}" alt="user" /></div>
-        <div class="message">${message}</div>
+        <div class="message">${encodeURIComponent(message).replace(/%3C/g,'&lt;').replace(/%3E/g,'&gt;')}</div>
       </div>
     `;
     userChatBox.innerHTML += markup;


### PR DESCRIPTION
I noticed that html in user's message is being rendered as html. If a user posts `<a href...>some text</a>`, it is rendered as a link in userChatBox. Clicking it even crashes Acode. Apart from not being able to use my message as reference, this causes other undesirable effect such as not being able to recopy my question for reuse. 

Here, I've updated that line to display user's message as text instead of being rendered as html.

This issue also existed in the previous version